### PR TITLE
Additional field case insensitivty

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 snowflake-snowpark-python==0.10.0
 Jinja2==3.1.2
 colorama==0.4.6
+python-dotenv

--- a/tips/framework/runners/framework_runner.py
+++ b/tips/framework/runners/framework_runner.py
@@ -59,7 +59,7 @@ class FrameworkRunner:
                     if fwMetaData["ADDITIONAL_FIELDS"] is not None
                     else ""
                 ).split("|"):
-                    splittedField = fld.strip()
+                    splittedField = fld.strip().upper()#making upper case to handle case-insensitively 
                     # Now split column and alias
                     if splittedField is not None and splittedField != "":
                         # In case expression and column alias have been delimited with multiple spaces, rather


### PR DESCRIPTION
All additional fields in process_cmd are upper-cased to avoid case-sensitivity issues

