### PR TITLE
Added PROC cmd_type for calling procs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -224,3 +224,17 @@ Following are the fields applicable for TRUNCATE command type:
 | Field Name | Mandatory? | Description |
 | ---------- | :-------: |-------------|
 | CMD_TGT | Yes | Specify the name of table from which data is to be deleted. <p>**Please include schema name with the object name e.g. [SCHEMA NAME].[OBJECT NAME] and all in CAPS please**</p> |
+
+
+### PROC
+This command type is for running 'call <proc>(<args>)' commands.
+
+The following fields are applicable for the PROC command type:
+
+| Field Name | Mandatory? | Description |
+| ---------- | :-------: |-------------|
+| CMD_SRC | Yes | Specify the name of the procedure here. <p>Provide the name without arguments. e.g. schema1.proc1 instead of schema1.proc1(varchar) <br>**Please include schema name with the procedure name e.g. [SCHEMA NAME].[PROCEDURE NAME] and all in CAPS please**</p> |
+| CMD_BINDS | No | If bind variables are used in the step, here you specify the name for bind variables, delimited by Pipe **"\|"** symbol. In this case, CMD_BINDS can be passed to the procedure if referenced in CMD_WHERE.  <p>Bind variable values are passed in at runtime in a JSON format. Names of bind variables defined here are interpreted as keys from the variable values JSON object passed in at run-time</p> |
+| CMD_WHERE | No | This is where you supply the arguments used by the procedure. </p>Provide the parametes in a comma delimited list, and reference CMD_BINDS using :<cmd_bind>. e.g. For a procedure with three parameters, PARAM, PARAM2, and PARAM3, and the first two parameters coming from their respective CMD_BINDS, CMD_WHERE could be: 'PARAM=:1,PARAM2=:2,PARAM3=\'ABCD\''</p> |
+
+**Please note that TIPS is not designed as an orchestrator and that this action should be treated strictly as a convenience action for edge cases.**

--- a/metadata_tables_ddl/process_cmd.sql
+++ b/metadata_tables_ddl/process_cmd.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS process_cmd (
     process_cmd_id                      NUMBER(38,0) NOT NULL,
     cmd_type                            VARCHAR(30) NOT NULL,
     cmd_src                             VARCHAR,
-    cmd_tgt                             VARCHAR NOT NULL,
+    cmd_tgt                             VARCHAR,
     cmd_where                           VARCHAR,
     cmd_binds                           VARCHAR,
     refresh_type                        VARCHAR(10),

--- a/tips/framework/actions/call_procedure_action.py
+++ b/tips/framework/actions/call_procedure_action.py
@@ -1,0 +1,60 @@
+from typing import Dict, List
+
+from tips.framework.actions.sql_action import SqlAction
+from tips.framework.actions.sql_command import SQLCommand
+from tips.framework.metadata.table_metadata import TableMetaData
+from tips.framework.utils.sql_template import SQLTemplate
+from tips.framework.utils.globals import Globals
+
+
+class CallProcedureAction(SqlAction):
+    _source: str
+    _whereClause: str
+    _metadata: TableMetaData
+    _binds: List[str]
+
+    def __init__(
+        self,
+        source: str,
+        whereClause: str,
+        binds: List[str],
+    ) -> None:
+        self._source = source
+        self._whereClause = whereClause
+        self._binds = binds
+
+    def getBinds(self) -> List[str]:
+        return self._binds
+
+    def getCommands(self) -> List[object]:
+        globalsInstance = Globals()
+
+        cmd: List[object] = []
+
+        ## append quotes with bind variable
+        cnt = 0
+        while True:
+            cnt += 1
+            if self._whereClause is not None and f":{cnt}" in self._whereClause:
+                self._whereClause = (
+                    self._whereClause.replace(f":{cnt}", f"':{cnt}'")
+                    if self._whereClause is not None
+                    else None
+                )
+            else:
+                break
+        
+        #use where clause in proc call, requires syntax change
+        self._whereClause=self._whereClause.replace('=','=>')
+
+        cmdStr = SQLTemplate().getTemplate(
+            sqlAction="call_procedure",
+            parameters={
+                "source": self._source,
+                "whereClause": self._whereClause
+            },
+        )
+
+        cmd.append(SQLCommand(sqlCommand=cmdStr, sqlBinds=self.getBinds()))
+
+        return cmd

--- a/tips/framework/factories/action_factory.py
+++ b/tips/framework/factories/action_factory.py
@@ -14,7 +14,7 @@ from tips.framework.actions.truncate_action import TruncateAction
 from tips.framework.actions.dq_test_action import DQTestAction
 from tips.framework.metadata.action_metadata import ActionMetadata
 from tips.framework.metadata.table_metadata import TableMetaData
-
+from tips.framework.actions.call_procedure_action import CallProcedureAction
 
 # Below is to initialise logging
 import logging
@@ -174,6 +174,13 @@ class ActionFactory:
                 cmdDQTests=actionMetaData.getCmdDQTests(),
                 whereClause=actionMetaData.getWhereClause(),
                 binds=actionMetaData.getBinds(),
+            )
+        elif actionMetaData.getCmdType() == "PROC":
+            logger.info('Running Call Procedure Action...')
+            action = CallProcedureAction(
+                source=actionMetaData.getSource(),
+                whereClause=actionMetaData.getWhereClause(),
+                binds=actionMetaData.getBinds()
             )
         else:
             logger.info("Running Default Action...")

--- a/tips/framework/templates/call_procedure.j2
+++ b/tips/framework/templates/call_procedure.j2
@@ -1,0 +1,1 @@
+CALL {{ parameters.source }} ( {{ parameters.whereClause }} )


### PR DESCRIPTION
New CMD_TYPE 'PROC', which allows procedures to be called in pipelines.

Added new action and changed action factory to accommodate.

Also made CMD_TGT in PROCESS_CMD nullable as this CMD_TYPE uses CMD_SRC only.